### PR TITLE
fix: allow search on 1 char query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
         <relativePath/>
     </parent>
 
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.14.1</version>
+            <version>1.14.2</version>
         </dependency>
 
         <dependency>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/no/fdk/referencedata/graphql/query/SearchQuery.java
+++ b/src/main/java/no/fdk/referencedata/graphql/query/SearchQuery.java
@@ -65,7 +65,7 @@ public class SearchQuery {
     public List<SearchHit> search(@Argument SearchRequest req) {
         String query = req.getQuery();
 
-        if (query != null && query.length() > 1) {
+        if (query != null && !query.isEmpty()) {
             return searchables.stream()
                     .filter(searchable -> req.getTypes().contains(searchable.getSearchType()))
                     .flatMap(searchable -> searchable.search(query))


### PR DESCRIPTION
Gjør det mulig å søke ved første tastetrykk slik at alle søkene i datasett-skjema fungerer på samme måte. 