### PR TITLE
feat: sort EU frequencies by most frequent

### DIFF
--- a/src/main/java/no/fdk/referencedata/eu/frequency/Frequency.java
+++ b/src/main/java/no/fdk/referencedata/eu/frequency/Frequency.java
@@ -17,4 +17,5 @@ public class Frequency {
     @Indexed
     String code;
     Map<String, String> label;
+    Integer sortIndex;
 }

--- a/src/main/java/no/fdk/referencedata/eu/frequency/FrequencyController.java
+++ b/src/main/java/no/fdk/referencedata/eu/frequency/FrequencyController.java
@@ -26,7 +26,7 @@ public class FrequencyController {
     public ResponseEntity<Frequencies> getFrequencies() {
         return ResponseEntity.ok(Frequencies.builder().frequencies(
                 StreamSupport.stream(frequencyRepository.findAll().spliterator(), false)
-                        .sorted(Comparator.comparing(Frequency::getUri))
+                        .sorted(Comparator.comparing(Frequency::getSortIndex))
                         .collect(Collectors.toList())).build());
     }
 

--- a/src/main/java/no/fdk/referencedata/eu/frequency/FrequencyHarvester.java
+++ b/src/main/java/no/fdk/referencedata/eu/frequency/FrequencyHarvester.java
@@ -73,45 +73,53 @@ public class FrequencyHarvester extends AbstractEuHarvester<Frequency> {
                 .doOnNext(literal -> label.put(literal.getLanguage(), literal.getString()))
                 .subscribe();
 
-        switch (code) {
-            case "1MIN":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hvert minutt");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvart minutt");
-                break;
-            case "5MIN":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hvert femte minutt");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvart femte minutt");
-                break;
-            case "10MIN":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hvert tiende minutt");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvart tiande minutt");
-                break;
-            case "15MIN":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hvert kvarter");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvart kvarter");
-                break;
-            case "30MIN":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hver halvtime");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvar halvtime");
-                break;
-            case "12HRS":
-                label.put(NORWEGIAN_BOKMAAL.code(), "hver tolvte time");
-                label.put(NORWEGIAN_NYNORSK.code(), "kvar tolvte time");
-                break;
-            case "AS_NEEDED":
-                label.put(NORWEGIAN_BOKMAAL.code(), "etter behov");
-                label.put(NORWEGIAN_NYNORSK.code(), "etter behov");
-                break;
-            case "NOT_PLANNED":
-                label.put(NORWEGIAN_BOKMAAL.code(), "ikke planlagt");
-                label.put(NORWEGIAN_NYNORSK.code(), "ikkje planlagt");
-                break;
-        }
+        int sortIndex = switch (code) {
+            case "CONT" -> 0;
+            case "UPDATE_CONT" -> 1;
+            case "1MIN" -> 2;
+            case "5MIN" -> 3;
+            case "10MIN" -> 4;
+            case "15MIN" -> 5;
+            case "30MIN" -> 6;
+            case "HOURLY" -> 7;
+            case "BIHOURLY" -> 8;
+            case "TRIHOURLY" -> 9;
+            case "12HRS" -> 10;
+            case "DAILY_2" -> 11;
+            case "DAILY" -> 12;
+            case "WEEKLY_5" -> 13;
+            case "WEEKLY_3" -> 14;
+            case "WEEKLY_2" -> 15;
+            case "WEEKLY" -> 16;
+            case "BIWEEKLY" -> 17;
+            case "MONTHLY_3" -> 18;
+            case "MONTHLY_2" -> 19;
+            case "MONTHLY" -> 20;
+            case "BIMONTHLY" -> 21;
+            case "QUARTERLY" -> 22;
+            case "ANNUAL_3" -> 23;
+            case "ANNUAL_2" -> 24;
+            case "ANNUAL" -> 25;
+            case "BIENNIAL" -> 26;
+            case "TRIENNIAL" -> 27;
+            case "QUADRENNIAL" -> 28;
+            case "QUINQUENNIAL" -> 29;
+            case "DECENNIAL" -> 30;
+            case "BIDECENNIAL" -> 31;
+            case "TRIDECENNIAL" -> 32;
+            case "AS_NEEDED" -> 33;
+            case "IRREG" -> 34;
+            case "OTHER" -> 35;
+            case "NOT_PLANNED" -> 36;
+            case "NEVER" -> 37;
+            default -> 100;
+        };
 
         return Frequency.builder()
                 .uri(frequency.getURI())
                 .code(frequency.getProperty(DC.identifier).getObject().toString())
                 .label(label)
+                .sortIndex(sortIndex)
                 .build();
     }
 

--- a/src/test/java/no/fdk/referencedata/eu/frequency/FrequencyControllerIntegrationTest.java
+++ b/src/test/java/no/fdk/referencedata/eu/frequency/FrequencyControllerIntegrationTest.java
@@ -71,9 +71,9 @@ public class FrequencyControllerIntegrationTest extends AbstractContainerTest {
         assertEquals(FREQUENCIES_SIZE, frequencies.getFrequencies().size());
 
         Frequency first = frequencies.getFrequencies().get(0);
-        assertEquals("http://publications.europa.eu/resource/authority/frequency/10MIN", first.getUri());
-        assertEquals("10MIN", first.getCode());
-        assertEquals("kvart tiande minutt", first.getLabel().get(Language.NORWEGIAN_NYNORSK.code()));
+        assertEquals("http://publications.europa.eu/resource/authority/frequency/CONT", first.getUri());
+        assertEquals("CONT", first.getCode());
+        assertEquals("kontinuerleg", first.getLabel().get(Language.NORWEGIAN_NYNORSK.code()));
     }
 
     @Test

--- a/src/test/resources/frequencies-sparql-result.ttl
+++ b/src/test/resources/frequencies-sparql-result.ttl
@@ -186,25 +186,41 @@ ns1:TRIDECENNIAL	skos:inScheme	ns2:frequency ;
 	dc:identifier	"TRIDECENNIAL" .
 ns1:1MIN	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every minute"@en ;
+	skos:prefLabel	"hvert minutt"@nb ;
+	skos:prefLabel	"kvart minutt"@nn ;
 	dc:identifier	"1MIN" .
 ns1:5MIN	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every five minutes"@en ;
+	skos:prefLabel	"hvert femte minutt"@nb ;
+	skos:prefLabel	"kvart femte minutt"@nn ;
 	dc:identifier	"5MIN" .
 ns1:10MIN	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every ten minutes"@en ;
+	skos:prefLabel	"hvert tiende minutt"@nb ;
+	skos:prefLabel	"kvart tiande minutt"@nn ;
 	dc:identifier	"10MIN" .
 ns1:15MIN	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every fifteen minutes"@en ;
+	skos:prefLabel	"hvert kvarter"@nb ;
+	skos:prefLabel	"kvart kvarter"@nn ;
 	dc:identifier	"15MIN" .
 ns1:30MIN	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every thirty minutes"@en ;
+	skos:prefLabel	"hver halvtime"@nb ;
+	skos:prefLabel	"kvar halvtime"@nn ;
 	dc:identifier	"30MIN" .
 ns1:12HRS	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"every twelve hours"@en ;
+	skos:prefLabel	"hver tolvte time"@nb ;
+	skos:prefLabel	"kvar tolvte time"@nn ;
 	dc:identifier	"12HRS" .
 ns1:AS_NEEDED	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"as needed"@en ;
+	skos:prefLabel	"etter behov"@nb ;
+	skos:prefLabel	"etter behov"@nn ;
 	dc:identifier	"AS_NEEDED" .
 ns1:NOT_PLANNED	skos:inScheme	ns2:frequency ;
 	skos:prefLabel	"not planned"@en ;
+	skos:prefLabel	"ikke planlagd"@nb ;
+	skos:prefLabel	"ikkje planlagd"@nn ;
 	dc:identifier	"NOT_PLANNED" .


### PR DESCRIPTION
resolve https://github.com/Informasjonsforvaltning/catalog-frontend/issues/1273

Fjerner også overskriving av norske tekster på noen av kodene, EU har oppdatert disse verdiene på sin side nå så det er ikke nødvendig å overskrive disse når vi høster derfra