### PR TITLE
chore: bump spring boot to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 
@@ -28,6 +28,9 @@
         <!--end standard properties-->
 
         <jena.version>6.0.0</jena.version>
+
+        <!-- Overrides Spring Boot 4.1.0 (42.7.11), which is still affected by CVE-2026-54291 -->
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Summary 

- Bump spring-boot-starter-parent from 4.0.5 to 4.1.0
- Brings Tomcat 11.0.22, which fixes 3 CRITICAL auth-bypass CVEs (CVE-2026-41293, CVE-2026-43512, CVE-2026-43515)
- Also pulls in Spring Framework 7.0.8, Spring Security 7.1.0, Jackson 2.21.4/3.1.4
- Pin postgresql to 42.7.13, overriding Spring Boot's 42.7.11 which is still affected by CVE-2026-54291
- No source changes needed; all 632 tests pass
