### PR TITLE
chore: bump base image to ubuntu noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.9.9-eclipse-temurin-21-jammy AS build
+FROM maven:3.9.9-eclipse-temurin-21-noble AS build
 WORKDIR /app
 COPY pom.xml ./
 COPY src ./src
 RUN mvn clean package --no-transfer-progress -DskipTests
 RUN mvn versions:display-dependency-updates --no-transfer-progress
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /app


### PR DESCRIPTION
# Summary 

- Bump build stage from `maven:3.9.9-eclipse-temurin-21-jammy` to `maven:3.9.9-eclipse-temurin-21-noble`
- Bump runtime stage from `eclipse-temurin:21-jre-jammy` to `eclipse-temurin:21-jre-noble`
- Ubuntu 22.04 -> 24.04 clears the bulk of the CRITICAL/HIGH OS-package findings in the Trivy report
- Maven version unchanged (3.9.9), no other Dockerfile changes
- App user stays UID/GID 1001, so no collision with the `ubuntu` UID 1000 user that noble ships
